### PR TITLE
Query users with certain group name

### DIFF
--- a/app/default/routes.py
+++ b/app/default/routes.py
@@ -1,5 +1,5 @@
 from . import default
-from flask import request, Response, jsonify
+from flask import request, jsonify
 from ..services.Database import Database
 
 db = Database()
@@ -13,6 +13,12 @@ def new_user():
 
     db.add_user(name, email, password, group)
 
-    print(db.get_users())
-
     return jsonify(result=True)
+
+@default.route('/api/get_group', methods=['GET'])
+def get_group():
+    group = request.json.get('group')
+    users = db.get_group(group)
+    return jsonify(result=users)
+
+

--- a/app/services/Database.py
+++ b/app/services/Database.py
@@ -17,10 +17,19 @@ class Database(object):
 
     def add_user(self, name, email, password, group):
 
-        self.cur.execute('''INSERT INTO users(name, email, password, group)
-                   VALUES
-                   ('{}', '{}', '{}' ,'{}');'''.format(name, email, password, group))
+        self.cur.execute('''INSERT INTO users
+        (name, email, password, group)
+        VALUES('{}', '{}', '{}' ,'{}');
+        '''.format(name, email, password, group))
 
         self.conn.commit()
+
+    def get_group(self, group):
+        self.cur.execute('''SELECT name FROM users
+                        WHERE team='{}' '''.format(group))
+        return(self.cur.fetchall())
+
+
+
 
 


### PR DESCRIPTION
# Description

Need to be able to query users and information about them based off of their group they are associated with. Currently, the route will query names based off the group name in the GET request. 

Fixes #14 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running two curl commands. First curl command with a valid group name. Second curl command with a invalid group name.
## Test A
### Input
- curl -i -H "Content-Type: application/json" -X GET -d  '{"group":"alpha"}' http://127.0.0.1: 5000/api/get_group
### Output
 {"result": [   [bar"],[ "bar" ], [ "Blair" ], [ "Blair"], [ "Blair" ]]     
    
## Test B

### Input
-curl -i -H "Content-Type: application/json" -X GET -d  '{"group":"WRONG"}' http://127.0.0.1: 5000/api/get_group

### Output
 {"result": [ ] }                     

# Checklist:

- [x ] Returns JSON file of names